### PR TITLE
Fix NRE for Linux authentication

### DIFF
--- a/Core/ExchangeServiceBase.cs
+++ b/Core/ExchangeServiceBase.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 return serviceCredentials;
 
             var networkCredentials = ((WebCredentials)serviceCredentials).Credentials as NetworkCredential;
-            if (networkCredentials != null)
+            if (url != null && networkCredentials != null)
             {
                 CredentialCache credentialCache = new CredentialCache();
                 credentialCache.Add(url, "NTLM", networkCredentials);


### PR DESCRIPTION
:ledger: JIRA
---
https://jira.parcsis.org/browse/CASEM-63823

:fire: Задача\Проблема
---
При подключении почты MSExchange на Linux выдается ошибка
>ERROR | 590 | 2022-01-28 09:49:46.7942 | SyncObjectResultExecutor.Execute => <no type>.lambda_method => ExchangeController.Authorize | CaseMap.Modules.Email.Exchange.Exceptions.ExchangeConnectException: URL сервера Exchange не определяется автоматически. Введите верный URL    at CaseMap.Modules.Email.Exchange.Services.ExchangeAuthorizationService.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeAuthorizationService.cs:line 50    at CaseMap.Modules.Email.Exchange.Controllers.ExchangeController.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Controllers/ExchangeController.cs:line 36 | CaseMap.Modules.Email.Exchange.Exceptions.ExchangeConnectException: URL сервера Exchange не определяется автоматически. Введите верный URL    at CaseMap.Modules.Email.Exchange.Services.ExchangeAuthorizationService.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeAuthorizationService.cs:line 50    at CaseMap.Modules.Email.Exchange.Controllers.ExchangeController.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Controllers/ExchangeController.cs:line 36 | ,

Данная ошибка выдается по причине ошибки в библиотеке для работы с MSExchange
>Microsoft.Exchange.WebServices.Data.ServiceLocalException: The Url property on the ExchangeService object must be set. at Microsoft.Exchange.WebServices.Data.ExchangeService.Validate() in /s/l/CaseMap/ews-managed-api/Core/ExchangeService.cs:line 5005 at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 198 at Microsoft.Exchange.WebServices.Data.ConvertIdRequest.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ConvertIdRequest.cs:line 102 at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.ValidateAndEmitRequest(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 660 at Microsoft.Exchange.WebServices.Data.SimpleServiceRequestBase.InternalExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/SimpleServiceRequestBase.cs:line 57 at Microsoft.Exchange.WebServices.Data.MultiResponseServiceRequest1.ExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/MultiResponseServiceRequest.cs:line 134 --- End of inner exception stack trace --- at System.Threading.Tasks.Task1.GetResultCore(Boolean waitCompletionNotification) at CaseMap.Modules.Email.Exchange.Services.ExchangeClient.HandleThrottling[T](Func1 func) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeClient.cs:line 175 at CaseMap.Modules.Email.Exchange.Services.ExchangeClient.TestExchangeService(ExchangeService service) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeClient.cs:line 95 at CaseMap.Modules.Email.Exchange.Services.ExchangeAuthorizationService.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeAuthorizationService.cs:line 62 at CaseMap.Modules.Email.Exchange.Controllers.ExchangeController.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Controllers/ExchangeController.cs:line 36 | Microsoft.Exchange.WebServices.Data.ServiceLocalException: The Url property on the ExchangeService object must be set. at Microsoft.Exchange.WebServices.Data.ExchangeService.Validate() in /s/l/CaseMap/ews-managed-api/Core/ExchangeService.cs:line 5005 at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 198 at Microsoft.Exchange.WebServices.Data.ConvertIdRequest.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ConvertIdRequest.cs:line 102 at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.ValidateAndEmitRequest(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 660 at Microsoft.Exchange.WebServices.Data.SimpleServiceRequestBase.InternalExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/SimpleServiceRequestBase.cs:line 57 at Microsoft.Exchange.WebServices.Data.MultiResponseServiceRequest1.ExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/MultiResponseServiceRequest.cs:line 134

:bulb: Реализация
---
Доработана библиотека для работы с MSExchange - https://github.com/AndreyVoronkovPravo/ews-managed-api/pull/1
Добавлен nuget-пакет с исправлением на https://nuget.test.case.one
Замена библиотека в проекте для работы с MSExchange на кастомную библиотеку

:checkered_flag: Тестирование
---
Ручное

:chains: Зона аффекта
---
Работа с почтой MSExchange
Необходима проверка на Windows и Linux

:speech_balloon: Комментарии
---
Дополнительные комментарии к пулу.
