### PR TITLE
CASEM-65011. Ошибка обработки исключения синхронизации почты Exchange

### DIFF
--- a/Microsoft.Exchange.WebServices.NETStandard.csproj
+++ b/Microsoft.Exchange.WebServices.NETStandard.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Exchange.WebServices.NETStandard</AssemblyName>
-    <PackageId>Microsoft.Exchange.WebServices.NETStandard</PackageId>
+    <PackageId>Microsoft.Exchange.WebServices.NETStandard.CaseOne</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -13,13 +13,14 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>sherlock1982</Authors>
-    <RepositoryUrl>https://github.com/sherlock1982/ews-managed-api</RepositoryUrl>
+    <Authors>Keepteam</Authors>
+    <RepositoryUrl>https://github.com/Keepteam/ews-managed-api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>ews exchange office365 Microsoft Web API Email Client Library C#</PackageTags>
-    <PackageProjectUrl>https://github.com/sherlock1982/ews-managed-api</PackageProjectUrl>
-    <Title>Microsoft.Exchange.WebServices.NETStandard</Title>
+    <PackageProjectUrl>https://github.com/Keepteam/ews-managed-api</PackageProjectUrl>
+    <Title>Microsoft.Exchange.WebServices.NETStandard.CaseOne</Title>
     <Description>The Exchange Web Services (EWS) Managed API provides a managed interface for developing .NET client applications that use EWS. By using the EWS Managed API, you can access almost all the information stored in an Office 365, Exchange Online, or Exchange Server mailbox.</Description>
+    <Version>$(VersionPrefix)</Version>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
:fire: Задача\Проблема
---
Ошибка проверки StatusCode при обработке исключения WebException
```
System.ObjectDisposedException: Cannot access a disposed object. Object name: 'System.Net.HttpWebResponse'.
	at System.Net.HttpWebResponse.CheckDisposed()
	at System.Net.HttpWebResponse.get_StatusCode()
```
 
:bulb: Реализация
---
В обработке ответа (класс ServiceRequestBase), создается EwsHttpWebResponse:IDisposble. Ему на вход передается WebException и из исключения выдергивается Response. При утилизации EwsHttpWebResponse (а это происходит в том же классе) мы утилизируем также Response. Поэтому далее обратиться к нему мы не можем, т.к. HttpWebResponse проверяет disposed при получении его параметров. В других похожих местах using не используется.
Возможно это минимально повлияет на память, но это используется в других местах и кажется это не его зона ответственности по утилизации ответа из WebException.

:chains: Зона аффекта
---
Обработка исключения синхронизации почты с Exchange

:speech_balloon: Комментарии
---
Github что-то намудрил с diff'ом. На самом деле там одна строка изменилась. Убрал using.
